### PR TITLE
Update documentation to clarify that file functions are not exported

### DIFF
--- a/lib/Acme/Unicodify.pm
+++ b/lib/Acme/Unicodify.pm
@@ -21,8 +21,8 @@ use File::Slurper 0.008 qw(read_text write_text);
   $foo = $translate->to_unicode('Hello, World');
   $bar = $translate->back_to_ascii($unified_string);
 
-  file_to_unicode('/tmp/infile', '/tmp/outfile');
-  file_back_to_ascii('/tmp/infile', '/tmp/outfile');
+  $translate->file_to_unicode('/tmp/infile', '/tmp/outfile');
+  $translate->file_back_to_ascii('/tmp/infile', '/tmp/outfile');
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
The documentation read as though the functions `file_to_unicode`  and `file_back_to_ascii` were exported.  This pull simply corrects the documentation to match the current implementation.  However, if your intent was to actually export the file functions.  Then you should reject this pull request and `use base qw{Exporter}; our @EXPORT_OK = qw{file_to_unicode file_back_to_ascii};`  and tweak the functions to determine if you are calling with 2 or 3 arguments.